### PR TITLE
Trigger phantomasFailure event when errors are thrown

### DIFF
--- a/tasks/lib/phantomas.js
+++ b/tasks/lib/phantomas.js
@@ -490,6 +490,7 @@ Phantomas.prototype.kickOff = function() {
         if ( e.stack ) {
           this.grunt.log.error( e.stack );
         }
+        this.grunt.event.emit('phantomasFailure', e);
       }.bind( this ) )
       .done();
 };


### PR DESCRIPTION
This exposes the error message, as well as allowing us to act when there are errors.
